### PR TITLE
Added sigmaX & sigmaY for more blur customisation

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,14 +49,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -94,7 +94,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -108,7 +108,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -120,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -155,21 +155,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.5.0"

--- a/lib/blur.dart
+++ b/lib/blur.dart
@@ -1,10 +1,13 @@
 library blur;
 
 import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 ///blur it's [child]
 ///[blur] is the value of blur effect, higher the blur more the blur effect (default value = 5)
+///[sigmaX] is the value of sigmaX used in ImageFilter.blur, if provided it will override the blur value (default value = null)
+///[sigmaY] is the value of sigmaY used in ImageFilter.blur, if provided it will override the blur value (default value = null)
 ///[blurColor] is the color of blur effect (default value = Colors.white)
 ///[borderRadius] is the radius of the child to be blurred
 ///[colorOpacity] is the opacity of the blurColor (default value = 0.5)
@@ -20,6 +23,8 @@ class Blur extends StatelessWidget {
     this.colorOpacity = 0.5,
     this.overlay,
     this.alignment = Alignment.center,
+    this.sigmaX,
+    this.sigmaY,
   }) : super(key: key);
 
   final Widget child;
@@ -29,6 +34,8 @@ class Blur extends StatelessWidget {
   final double colorOpacity;
   final Widget? overlay;
   final AlignmentGeometry alignment;
+  final double? sigmaX;
+  final double? sigmaY;
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +46,10 @@ class Blur extends StatelessWidget {
           child,
           Positioned.fill(
             child: BackdropFilter(
-              filter: ImageFilter.blur(sigmaX: blur, sigmaY: blur),
+              filter: ImageFilter.blur(
+                sigmaX: sigmaX ?? blur,
+                sigmaY: sigmaY ?? blur,
+              ),
               child: Container(
                 decoration: BoxDecoration(
                   color: blurColor.withOpacity(colorOpacity),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,7 +87,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -101,7 +101,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -148,21 +148,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.5.0"


### PR DESCRIPTION
Previously you could not customise the sigmaX & sigmaY in the `ImageFilter.blur` widget, it used the same blur value for both these parameters.

Now you can pass in sigmaX or sigmaY values to override the value for sigmaX & sigmaY.